### PR TITLE
Update last known location only if changed

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/services/BackgroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/services/BackgroundService.kt
@@ -168,7 +168,7 @@ class BackgroundService : LifecycleService(), KoinComponent {
             ) { mode, addressOrLocation ->
                 mode to addressOrLocation
             }.collect { (mode, addressOrLocation) ->
-                notifyOngoing(mode, addressOrLocation)
+                notifyOngoing(mode, addressOrLocation?.string())
             }
         }
     }


### PR DESCRIPTION
Noticed that in move mode, the notification would update with
coordinates, then quickly with its address then quickly to
coordinates which would be the same as the first coordinates

This should only update the last known location if changed
