### PR TITLE
Change location request for different modes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/tracking/location/Request.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/tracking/location/Request.kt
@@ -23,16 +23,16 @@ fun Request.Companion.forMonitoringMode(monitoringMode: MonitoringMode) = when (
             interval = 1.hours,
             priority = Priority.LowPower,
             minUpdateDistanceMeters = 500f,
-            fastestInterval = 1.seconds,
+            fastestInterval = 20.minutes,
         )
     }
 
     MonitoringMode.SignificantChanges -> {
         Request(
-            interval = 1.minutes,
+            interval = 5.minutes,
             priority = Priority.BalancedPowerAccuracy,
-            minUpdateDistanceMeters = 500f,
-            fastestInterval = 1.seconds,
+            minUpdateDistanceMeters = 100f,
+            fastestInterval = 1.minutes,
         )
     }
 


### PR DESCRIPTION
Want to use significant changes and slow mode more than I currently
do so making them request locations less frequently. Might remove
maybe one of them if still not using them
