### PR TITLE
Fix location request restarting

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -50,7 +50,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyD7v-Ixs8EITpXbyJh-Ga6JxbtM63Yfu5c" />
+            android:value="AIzaSyDD5XWlNwSkvnFQ4dLrKB_Lz13vquWScpQ" />
 
         <activity
             android:name="com.ramitsuri.locationtracking.MainActivity"

--- a/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/tracking/location/AndroidLocationProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/tracking/location/AndroidLocationProvider.kt
@@ -13,6 +13,8 @@ import com.google.android.gms.location.LocationRequest.Builder as GmsRequestBuil
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority as GmsPriority
+import com.ramitsuri.locationtracking.log.logE
+import com.ramitsuri.locationtracking.log.logI
 import com.ramitsuri.locationtracking.log.logW
 import com.ramitsuri.locationtracking.model.Location
 import kotlin.coroutines.resume
@@ -58,10 +60,14 @@ class AndroidLocationProvider(context: Context) : LocationProvider {
             callback,
             handler.looper,
         ).addOnFailureListener { e ->
+            logE(TAG, e) { "Failed to start location updates" }
             close(e)
+        }.addOnSuccessListener {
+            logI(TAG) { "Starting location updates: $callback" }
         }
 
         awaitClose {
+            logI(TAG) { "Stopping location updates: $callback" }
             fusedLocationProviderClient.removeLocationUpdates(callback)
         }
     }
@@ -86,7 +92,7 @@ class AndroidLocationProvider(context: Context) : LocationProvider {
                 // Turns out location can be null! Especially if there's no location available or if
                 // locations are turned off on the device.
                 if (location == null) {
-                    logW("LocationProvider") {
+                    logW(TAG) {
                         "No location available for single high accuracy request. Device location " +
                             "disabled?"
                     }
@@ -133,4 +139,8 @@ class AndroidLocationProvider(context: Context) : LocationProvider {
         // Convert m/s to km/h
         velocity = if (hasSpeed()) ((speed * 3.6).toInt()) else 0,
     )
+
+    companion object {
+        private const val TAG = "AndroidLocationProvider"
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/DataStoreKeyValueStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/DataStoreKeyValueStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import okio.Path
@@ -21,6 +22,7 @@ internal class DataStoreKeyValueStore(
             .map {
                 it[stringPreferencesKey(key.value)] ?: defaultValue
             }
+            .distinctUntilChanged()
     }
 
     override suspend fun getString(key: Key, defaultValue: String?): String? {


### PR DESCRIPTION
Apparently, writing any value to data store updates flows for all
values in the datastore. So, saving last location to data store,
triggered refresh for the monitoring mode, which triggered the
location request again, triggering a new location, which gets saved
and retriggers monitoring mode change and the cycle goes on.

Also used flatMapLatest instead of collect inside collect.
Added some logs as well

Also changed the maps api key
