### PR TITLE
Track single location with regions list

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/tracking/Tracker.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/tracking/Tracker.kt
@@ -77,6 +77,7 @@ class Tracker(
                     bssid = wifiInfo.bssid,
                     battery = batteryInfoProvider.getLevel(),
                     batteryStatus = batteryInfoProvider.getChargingStatus(),
+                    inRegions = listOf(),
                 ).let {
                     locationRepository.insert(it)
                     onNewLocation(it)


### PR DESCRIPTION
Using inRegions as a placeholder for adding POI information to single
locations. Will use inRegions null vs empty list to differentiate
between which locations need additional input from user for where
they were.
