### PR TITLE
Increase min accuracy when tracking

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/MainApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/MainApp.kt
@@ -151,6 +151,7 @@ class MainApp : Application(), KoinComponent {
                         isUploadWorkerRunning = { UploadWorker.isRunning(this@MainApp) },
                         upload = { UploadWorker.enqueueImmediate(this@MainApp) },
                         timeZone = get<TimeZone>(),
+                        settings = get<Settings>(),
                     )
                 }
 

--- a/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/ui/navigation/NavGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/ui/navigation/NavGraph.kt
@@ -76,6 +76,7 @@ fun NavGraph(
                         viewState = viewState,
                         onBaseUrlChange = viewModel::setBaseUrl,
                         onDeviceNameChange = viewModel::setDeviceName,
+                        onMinAccuracyForDisplayChange = viewModel::setMinAccuracyForDisplay,
                         onKillApp = onKillApp,
                         onNavBack = {
                             navController.navigateUp()

--- a/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/ramitsuri/locationtracking/ui/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ fun SettingsScreen(
     onNavBack: () -> Unit,
     onBaseUrlChange: (String) -> Unit,
     onDeviceNameChange: (String) -> Unit,
+    onMinAccuracyForDisplayChange: (Int) -> Unit,
     onKillApp: () -> Unit,
     onServiceStart: () -> Unit,
     onServiceStop: () -> Unit,
@@ -72,6 +73,13 @@ fun SettingsScreen(
             label = stringResource(R.string.device_name_hint),
             enabled = !viewState.isUploadWorkerRunning,
             onTextSet = onDeviceNameChange,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        TextField(
+            text = viewState.minAccuracyForDisplay.toString(),
+            label = stringResource(R.string.min_accuracy_for_display_hint),
+            enabled = true,
+            onTextSet = { onMinAccuracyForDisplayChange(it.toIntOrNull() ?: 0) },
         )
         Spacer(modifier = Modifier.height(8.dp))
         Button(

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -33,6 +33,7 @@
 
     <string name="url_hint">"URL: "</string>
     <string name="device_name_hint">"Device Name: "</string>
+    <string name="min_accuracy_for_display_hint">"Min Accuracy (meters): "</string>
 
     <string name="wifi_rule_when_wifi_disconnected">"When device disconnects from WiFi"</string>
     <string name="wifi_rule_when_wifi_connected">"When device connects to WiFi"</string>

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/model/MonitoringMode.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/model/MonitoringMode.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.encoding.Encoder
 @Serializable(with = MonitoringModeSerializer::class)
 enum class MonitoringMode(
     override val value: String,
-    val horizontalAccuracyMeters: Float = 0f,
 ) : DbEnum {
     // Owntracks quiet
     Off(
@@ -21,17 +20,14 @@ enum class MonitoringMode(
     // Owntracks manual - very slow updates
     Rest(
         value = "rest",
-        horizontalAccuracyMeters = 200f,
     ),
 
     Walk(
         value = "walk",
-        horizontalAccuracyMeters = 50f,
     ),
 
     Move(
         value = "move",
-        horizontalAccuracyMeters = 100f,
     ),
     ;
 

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/DataStoreKeyValueStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/DataStoreKeyValueStore.kt
@@ -3,6 +3,7 @@ package com.ramitsuri.locationtracking.settings
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -19,10 +20,9 @@ internal class DataStoreKeyValueStore(
     override fun getStringFlow(key: Key, defaultValue: String?): Flow<String?> {
         return dataStore
             .data
-            .map {
+            .mapDistinct {
                 it[stringPreferencesKey(key.value)] ?: defaultValue
             }
-            .distinctUntilChanged()
     }
 
     override suspend fun getString(key: Key, defaultValue: String?): String? {
@@ -39,9 +39,30 @@ internal class DataStoreKeyValueStore(
         }
     }
 
+    override fun getIntFlow(key: Key, defaultValue: Int): Flow<Int> {
+        return dataStore
+            .data
+            .mapDistinct {
+                it[intPreferencesKey(key.value)] ?: defaultValue
+            }
+    }
+
+    override suspend fun getInt(key: Key, defaultValue: Int): Int {
+        return getIntFlow(key, defaultValue).first()
+    }
+
+    override suspend fun putInt(key: Key, value: Int) {
+        dataStore.edit {
+            it[intPreferencesKey(key.value)] = value
+        }
+    }
+
     private suspend fun <T> remove(key: Preferences.Key<T>) {
         dataStore.edit {
             it.remove(key)
         }
     }
+
+    private inline fun <T, R> Flow<T>.mapDistinct(crossinline transform: suspend (value: T) -> R) =
+        map(transform).distinctUntilChanged()
 }

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/Key.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/Key.kt
@@ -5,4 +5,5 @@ enum class Key(val value: String) {
     BASE_URL("base_url"),
     DEVICE_NAME("device_name"),
     LAST_KNOWN_LOCATION("last_known_location"),
+    MIN_ACCURACY_FOR_DISPLAY("min_accuracy_for_display"),
 }

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/KeyValueStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/KeyValueStore.kt
@@ -8,4 +8,10 @@ internal interface KeyValueStore {
     suspend fun getString(key: Key, defaultValue: String?): String?
 
     suspend fun putString(key: Key, value: String?)
+
+    fun getIntFlow(key: Key, defaultValue: Int): Flow<Int>
+
+    suspend fun getInt(key: Key, defaultValue: Int): Int
+
+    suspend fun putInt(key: Key, value: Int)
 }

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/settings/Settings.kt
@@ -64,4 +64,12 @@ class Settings internal constructor(
     suspend fun setLastKnownLocation(lastKnownLocation: Location) {
         keyValueStore.putString(Key.LAST_KNOWN_LOCATION, json.encodeToString(lastKnownLocation))
     }
+
+    fun getMinAccuracyForDisplay(): Flow<Int> {
+        return keyValueStore.getIntFlow(Key.MIN_ACCURACY_FOR_DISPLAY, 100)
+    }
+
+    suspend fun setMinAccuracyForDisplay(minAccuracyForDisplay: Int) {
+        keyValueStore.putInt(Key.MIN_ACCURACY_FOR_DISPLAY, minAccuracyForDisplay)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/tracking/Tracker.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/tracking/Tracker.kt
@@ -108,8 +108,8 @@ class Tracker(
                         ?.let { locationRequest ->
                             locationProvider.requestUpdates(locationRequest)
                                 .mapNotNull { location ->
-                                    if (location.accuracy > mode.horizontalAccuracyMeters) {
-                                        logI(TAG) { "Ignoring $location" }
+                                    if (location.accuracy > MIN_LOCATION_ACCURACY_METERS) {
+                                        logI(TAG) { "Ignoring because inaccurate $location" }
                                         null
                                     } else {
                                         val wifiInfo = wifiInfoProvider.wifiInfo.value
@@ -195,6 +195,7 @@ class Tracker(
 
     companion object {
         private const val TAG = "Tracker"
+        private const val MIN_LOCATION_ACCURACY_METERS = 500
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/ui/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.ramitsuri.locationtracking.model.Location
 import com.ramitsuri.locationtracking.permissions.PermissionResult
 import com.ramitsuri.locationtracking.repository.LocationRepository
+import com.ramitsuri.locationtracking.settings.Settings
 import com.ramitsuri.locationtracking.utils.combine
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -26,6 +28,7 @@ class HomeViewModel(
     isUploadWorkerRunning: () -> Flow<Boolean>,
     private val upload: () -> Unit,
     private val timeZone: TimeZone,
+    private val settings: Settings,
 ) : ViewModel() {
     private val viewMode =
         MutableStateFlow<HomeViewState.ViewMode>(HomeViewState.ViewMode.LastKnownLocation())
@@ -81,7 +84,7 @@ class HomeViewModel(
             locationRepository.get(
                 from = from,
                 to = to,
-                minAccuracyMeters = 100,
+                minAccuracyMeters = settings.getMinAccuracyForDisplay().first(),
             ).let { locations ->
                 viewMode.update {
                     HomeViewState.ViewMode.LocationsForDate(

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/ui/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/ui/settings/SettingsViewModel.kt
@@ -19,12 +19,14 @@ class SettingsViewModel(
         settings.getDeviceNameFlow(),
         isUploadWorkerRunning(),
         isServiceRunning(),
-    ) { url, deviceName, isUploadWorkerRunning, isServiceRunning ->
+        settings.getMinAccuracyForDisplay(),
+    ) { url, deviceName, isUploadWorkerRunning, isServiceRunning, minAccuracyForDisplay ->
         SettingsViewState(
             baseUrl = url,
             deviceName = deviceName,
             isUploadWorkerRunning = isUploadWorkerRunning,
             isServiceRunning = isServiceRunning,
+            minAccuracyForDisplay = minAccuracyForDisplay,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -41,6 +43,12 @@ class SettingsViewModel(
     fun setDeviceName(deviceName: String) {
         viewModelScope.launch {
             settings.setDeviceName(deviceName)
+        }
+    }
+
+    fun setMinAccuracyForDisplay(minAccuracyForDisplay: Int) {
+        viewModelScope.launch {
+            settings.setMinAccuracyForDisplay(minAccuracyForDisplay)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/ui/settings/SettingsViewState.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/ui/settings/SettingsViewState.kt
@@ -5,4 +5,5 @@ data class SettingsViewState(
     val deviceName: String = "",
     val baseUrl: String = "",
     val isServiceRunning: Boolean = false,
+    val minAccuracyForDisplay: Int = 0,
 )


### PR DESCRIPTION
Increase min accuracy for tracking to 500 meters to get more
locations. And allow for customizable accuracy when getting locations
to show on map instead.
