### PR TITLE
Delay sending mode change to wear os

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/ramitsuri/locationtracking/di/Koin.kt
@@ -56,7 +56,7 @@ private val coreModule = module {
     }
 
     single<CoroutineScope> {
-        CoroutineScope(SupervisorJob())
+        CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
     }
 
     single<CoroutineDispatcher>(qualifier = KoinQualifier.IO_DISPATCHER) {

--- a/phone/src/main/java/com/ramitsuri/locationtracking/services/BackgroundService.kt
+++ b/phone/src/main/java/com/ramitsuri/locationtracking/services/BackgroundService.kt
@@ -30,6 +30,8 @@ import com.ramitsuri.locationtracking.tracking.location.LocationProvider
 import com.ramitsuri.locationtracking.tracking.wifi.WifiInfoProvider
 import com.ramitsuri.locationtracking.ui.label
 import com.ramitsuri.locationtracking.wear.WearDataSharingClient
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -39,6 +41,7 @@ import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
+import kotlin.time.Duration.Companion.seconds
 
 class BackgroundService : LifecycleService(), KoinComponent {
     private val permissionChecker: PermissionChecker by inject()
@@ -71,6 +74,8 @@ class BackgroundService : LifecycleService(), KoinComponent {
     }
 
     private var hasBeenStartedExplicitly = false
+
+    private var postToWearOsJob: Job? = null
 
     override fun onCreate() {
         logD(TAG) { "onCreate" }
@@ -209,10 +214,14 @@ class BackgroundService : LifecycleService(), KoinComponent {
             }
             launch {
                 settings.getMonitoringMode().collect {
-                    wearDataSharingClient.postMonitoringMode(
-                        mode = it,
-                        to = WearDataSharingClient.To.Wear,
-                    )
+                    postToWearOsJob?.cancel()
+                    postToWearOsJob = launch {
+                        delay(3.seconds)
+                        wearDataSharingClient.postMonitoringMode(
+                            mode = it,
+                            to = WearDataSharingClient.To.Wear,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Noticed that wear os won't always vibrate on receiving mode change
and that started happening when delay was added to the receiving
service before vibrating/showing toast because mode would change
frequently, when wifi dropped for example.
Thinking it might be that background service exits because it's not
aware of the coroutine being run.
Moving that delay to be at the source instead now
